### PR TITLE
salt: Ensure git-lfs is installed in all runners

### DIFF
--- a/saltstack/salt/github-actions/runner/init.sls
+++ b/saltstack/salt/github-actions/runner/init.sls
@@ -6,6 +6,11 @@ github:
     - groups:
       - docker
 
+install:
+  pkg.installed:
+    - pkgs:
+      - git-lfs
+
 runner-mkdir:
   file.directory:
     - name: /opt/actions-runner


### PR DESCRIPTION
## Description

Installs git-lfs on all github action runners

## Why is this needed

boots and maybe other repos need git-lfs to checkout and there isn't an action to install it that I could find. I'm not sure it makes sense to re-install it for every action so decided to do it as part of the runner's bring up.
